### PR TITLE
schedule joinOrCancel API

### DIFF
--- a/src/main/java/stg/onyou/controller/ClubController.java
+++ b/src/main/java/stg/onyou/controller/ClubController.java
@@ -166,29 +166,26 @@ public class ClubController {
 
     }
 
-    @PostMapping("/schedules/{id}/register")
-    public Header<String> registerClubSchedule(@PathVariable Long id, HttpServletRequest httpServletRequest){
+    @PostMapping("/{clubId}/schedules/{scheduleId}/joinOrCancel")
+    public Header<String> joinOrCancelClubSchedule(@PathVariable Long clubId, @PathVariable Long scheduleId, HttpServletRequest httpServletRequest){
 
         Long userId = Long.parseLong(httpServletRequest.getAttribute("userId").toString());
 
-        UserClubSchedule userClubSchedule = clubService.registerClubSchedule(id, userId);
-        if(userClubSchedule == null){
-            throw new CustomException(ErrorCode.CLUB_SCHEDULE_MUTATION_ERROR);
-        }
+        UserClubSchedule userClubSchedule = clubService.joinOrCacnelClubSchedule(clubId, scheduleId, userId);
 
         return Header.OK("user_id: "+userClubSchedule.getUser().getId()+", club_schedule_id: "+ userClubSchedule.getClubSchedule().getId());
 
     }
 
-    @DeleteMapping("/schedules/{id}/cancel")
-    public Header<String> cancelClubSchedule(@PathVariable Long id, HttpServletRequest httpServletRequest){
-
-        Long userId = Long.parseLong(httpServletRequest.getAttribute("userId").toString());
-
-        clubService.cancelClubSchedule(id, userId);
-
-        return Header.OK("Deleted successfully");
-
-    }
+//    @DeleteMapping("{clubId}/schedules/{scheduleId}/cancel")
+//    public Header<String> cancelClubSchedule(@PathVariable Long clubId, @PathVariable Long scheduleId, HttpServletRequest httpServletRequest){
+//
+//        Long userId = Long.parseLong(httpServletRequest.getAttribute("userId").toString());
+//
+//        clubService.cancelClubSchedule(clubId, scheduleId, userId);
+//
+//        return Header.OK("Deleted successfully");
+//
+//    }
 
 }

--- a/src/main/java/stg/onyou/model/network/response/ClubRoleResponse.java
+++ b/src/main/java/stg/onyou/model/network/response/ClubRoleResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import stg.onyou.model.ApplyStatus;
 import stg.onyou.model.Role;
 
 @Data
@@ -15,5 +16,6 @@ public class ClubRoleResponse {
     private Long userId;
     private Long clubId;
     private Role role;
+    private ApplyStatus applyStatus;
 
 }

--- a/src/main/java/stg/onyou/model/network/response/UserResponse.java
+++ b/src/main/java/stg/onyou/model/network/response/UserResponse.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import stg.onyou.model.ApplyStatus;
+import stg.onyou.model.Role;
 
 import java.time.LocalDateTime;
 
@@ -22,6 +23,7 @@ public class UserResponse {
     private char sex;
     private String email;
     private LocalDateTime created;
+    private Role role;
 
 }
 

--- a/src/main/java/stg/onyou/service/ClubService.java
+++ b/src/main/java/stg/onyou/service/ClubService.java
@@ -86,16 +86,22 @@ public class ClubService {
                         () -> new CustomException(ErrorCode.CLUB_NOT_FOUND)
                 );
 
+        ClubRoleResponse clubRoleResponse;
         UserClub userClub = userClubRepository.findByUserAndClub(user, club)
-                .orElseThrow(
-                        () -> new CustomException(ErrorCode.USER_CLUB_NOT_FOUND)
-                );
-
-        ClubRoleResponse clubRoleResponse = ClubRoleResponse.builder()
-                .userId(userClub.getUser().getId())
-                .clubId(userClub.getClub().getId())
-                .role(userClub.getRole())
-                .build();
+                .orElse(null);
+        if(userClub == null){   // userClub이 존재하지 않을 경우에는 role, applyStatus 를 null로 반환
+            clubRoleResponse = ClubRoleResponse.builder()
+                    .userId(user.getId())
+                    .clubId(club.getId())
+                    .build();
+        } else {
+            clubRoleResponse = ClubRoleResponse.builder()
+                    .userId(user.getId())
+                    .clubId(club.getId())
+                    .role(userClub.getRole())
+                    .applyStatus(userClub.getApplyStatus())
+                    .build();
+        }
 
         return Header.OK(clubRoleResponse);
 

--- a/src/main/java/stg/onyou/service/ClubService.java
+++ b/src/main/java/stg/onyou/service/ClubService.java
@@ -607,7 +607,6 @@ public class ClubService {
                         .map(r -> r.getName())
                         .orElse(null)
                 )
-                // applyStatus도 이 api서 현재 사용자 id값을 url에 포함시켜서 받아와야 할지. 아니면 별도의 api로 가져와야 할지.
                 .build();
 
         return clubResponse;
@@ -630,6 +629,7 @@ public class ClubService {
                 .sex(user.getSex())
                 .email(user.getAccount_email())
                 .created(user.getCreated())
+                .role(userClub.getRole())
                 .build();
 
         return userResponse;


### PR DESCRIPTION
1. register, cancel API 삭제
-> joinOrCancel API로 통합
    - userClubSchedule row가 존재하면 삭제, 존재하지 않으면 추가
    - joinOrCancel 시, scheduleId가 속한 clubId가 아닐 경우 권한에러 처리
  
2. selectClub 시 member리스트에 role 포함해서 보내게 수정
3.  selectClubRole에 role, applyStatus 포함해서 보내게 수정